### PR TITLE
Adding travis ci yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 python:
-  - '2.6'
   - '2.7'
 install:
   - pip install -q -e sdk/.
 script:
-  - python setup.py test
+  - python sdk/setup.py test
 deploy:
   provider: pypi
   user: svoorhees

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - '2.6'
+  - '2.7'
+install:
+  - pip install -q -e sdk/.
+script:
+  - python setup.py test
+deploy:
+  provider: pypi
+  user: svoorhees
+  password:
+    secure: Tr6hcCIKsZ3L9dm/O9HhAa7UxGNMA2dpn2vNpDgIvCcBlNn3cdu8uvKW+tyY6rQncrsJwM/gi2Sw+hGBzyULoIFirbNTaS3BNeh4xcbtcwdOQsfRRRdb1OWsEVrvi1Q8NL99v4X5HErg8Pf8hOhYZg7TLwCzBR/OvQHnCv6xF00=
+  on:
+    tags: true
+    repo: autodesk-cloud/ochopod
+    branch: master


### PR DESCRIPTION
Added the .travis.yml file to enable Travis integration.  Build, test and push to pypi.  Pypi is currently set to only go to pypi on a tag.
