### PR TITLE
Fixed setuptools issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ENV DEBIAN_FRONTEND noninteractive
 # - start supervisor
 #
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install git curl python python-requests supervisor
-RUN curl https://bootstrap.pypa.io/get-pip.py | python
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - --no-setuptools --no-wheel
+RUN pip install setuptools==19.7
 ADD resources/supervisor/supervisord.conf /etc/supervisor/supervisord.conf
 RUN pip install git+https://github.com/autodesk-cloud/ochopod.git
 RUN apt-get -y autoremove


### PR DESCRIPTION
With the latest version of setuptools (20.3.1), Ochothon does not work,
e.g. running the 'toolset' command from within an Ochothon container
produces this error:

root@35740c15469f:/# toolset
Traceback (most recent call last):
  File "/usr/local/bin/toolset", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2749,
in <module>
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 444, in
_build_master
    ws.require(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 725, in
require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 633, in
resolve
    requirements.extend(dist.requires(req.extras)[::-1])
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2291,
in requires
    dm = self._dep_map
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2484,
in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2501,
in _compute_dependencies
    from _markerlib import compile as compile_marker
ImportError: No module named _markerlib
